### PR TITLE
Commit to A_I1_shared

### DIFF
--- a/src/r1cs/prover.rs
+++ b/src/r1cs/prover.rs
@@ -589,6 +589,7 @@ impl<'g, T: BorrowMut<Transcript>> Prover<'g, T> {
         .compress();
 
         let transcript = self.transcript.borrow_mut();
+        transcript.append_point(b"A_I1_shared", &A_I1_shared);
         transcript.append_point(b"A_I1", &A_I1);
         transcript.append_point(b"A_O1", &A_O1);
         transcript.append_point(b"S1", &S1);

--- a/src/r1cs/verifier.rs
+++ b/src/r1cs/verifier.rs
@@ -373,6 +373,7 @@ impl<T: BorrowMut<Transcript>> Verifier<T> {
         transcript.append_u64(b"m", self.V.len() as u64);
 
         let n1 = self.num_vars;
+        transcript.validate_and_append_point(b"A_I1_shared", &proof.A_I1_shared)?;
         transcript.validate_and_append_point(b"A_I1", &proof.A_I1)?;
         transcript.validate_and_append_point(b"A_O1", &proof.A_O1)?;
         transcript.validate_and_append_point(b"S1", &proof.S1)?;


### PR DESCRIPTION
We need to commit to the `A_I1_shared` piece, as otherwise any linked proof could supply a dummy `A_I1_shared` and it will not be checked against the proof itself.